### PR TITLE
Issue: Screen is not initialized on power cycle

### DIFF
--- a/Firmware/ARYTHMATIK_Euclid/ARYTHMATIK_Euclid.ino
+++ b/Firmware/ARYTHMATIK_Euclid/ARYTHMATIK_Euclid.ino
@@ -125,6 +125,7 @@ void setup() {
    // }
   
   // OLED setting
+  delay(1000); // Screen needs a sec to initialize
   display.begin(SSD1306_SWITCHCAPVCC, 0x3C);
   display.setTextSize(1);
   display.setTextColor(WHITE);

--- a/Firmware/ARYTHMATIK_Gate-seq/ARYTHMATIK_Gate-seq.ino
+++ b/Firmware/ARYTHMATIK_Gate-seq/ARYTHMATIK_Gate-seq.ino
@@ -218,6 +218,8 @@ const static word bnk4_ptn[8][12]PROGMEM = {
 void setup() {
 
 
+  delay(1000); // Screen needs a sec to initialize
+
   // ディスプレイの初期化
   display.begin(SSD1306_SWITCHCAPVCC, 0x3C);
 


### PR DESCRIPTION
Add a 1-second delay to the module startup to prevent out-of-sync conditions with screen initialization.